### PR TITLE
Remove stale root vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "buildCommand": "cd frontend && bun install --frozen-lockfile && bun run build",
-  "installCommand": "echo 'install handled by buildCommand'",
-  "outputDirectory": "frontend/.next"
-}


### PR DESCRIPTION
Vercel project rootDirectory is now 'frontend', so the repo-root vercel.json with cd-frontend commands runs from inside frontend/ and fails. Drop the file.